### PR TITLE
Jko/futurize

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,13 @@
+dependencies:
+  cache_directories:
+    - .pip-cache
+    - .pyenv
+
+  pre:
+    - pyenv shell 2.6.8; $(pyenv which pip) install -r --download-cache test-requirements.txt
+    - pyenv shell 3.3.3; $(pyenv which pip) install -r --download-cache test-requirements.txt
+
 test:
   override:
-    - pyenv shell 2.6.8; $(pyenv which pip) install -r test-requirements.txt
-    - pyenv shell 2.6.8; $(pyenv which python) -m py.test testing
-    - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
-    - pyenv shell 3.3.3; $(pyenv which python) -m py.test testing
+    - pyenv shell 2.6.8; $(pyenv which py.test) testing
+    - pyenv shell 3.3.3; $(pyenv which py.test) testing

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,6 @@
-machine:
-  python:
-    version: 3.3.3
-dependencies:
-  override:
-    - pip install --upgrade pip
 test:
   override:
-    - pip install -r test-requirements.txt
-    - py.test testing
+    - pyenv shell 2.6.8; $(pyenv which pip) install -r test-requirements.txt
+    - pyenv shell 2.6.8; $(pyenv which python) -m py.test testing
+    - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
+    - pyenv shell 3.3.3; $(pyenv which python) -m py.test testing

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,4 @@
 dependencies:
-  cache_directories:
-    - .pip-cache
-    - .pyenv
-
   pre:
     - pyenv shell 2.6.8; $(pyenv which pip) install --upgrade pip
     - pyenv shell 3.3.3; $(pyenv which pip) install --upgrade pip

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   python:
     version: 3.3.3
+dependencies:
+  override:
+    - pip install --upgrade pip
 test:
   override:
     - pip install -r test-requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
-
+machine:
+  python:
+    version: 3.3.1
 test:
   override:
     - pip install -r test-requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ dependencies:
   pre:
     - pyenv shell 2.6.8; $(pyenv which pip) install -r test-requirements.txt
     - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
+    - pyenv shell 2.6.8; $(pyenv which python) setup.py install
+    - pyenv shell 3.3.3; $(pyenv which python) setup.py install
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ dependencies:
     - .pyenv
 
   pre:
+    - pyenv shell 2.6.8; $(pyenv which pip) install --upgrade pip
+    - pyenv shell 3.3.3; $(pyenv which pip) install --upgrade pip
     - pyenv shell 2.6.8; $(pyenv which pip) install -r test-requirements.txt
     - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
     - pyenv shell 2.6.8; $(pyenv which python) setup.py install

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ dependencies:
     - .pyenv
 
   pre:
-    - pyenv shell 2.6.8; $(pyenv which pip) install -r --download-cache test-requirements.txt
-    - pyenv shell 3.3.3; $(pyenv which pip) install -r --download-cache test-requirements.txt
+    - pyenv shell 2.6.8; $(pyenv which pip) install --download-cache -r test-requirements.txt
+    - pyenv shell 3.3.3; $(pyenv which pip) install --download-cache -r test-requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ dependencies:
     - .pyenv
 
   pre:
-    - pyenv shell 2.6.8; $(pyenv which pip) install --download-cache -r test-requirements.txt
-    - pyenv shell 3.3.3; $(pyenv which pip) install --download-cache -r test-requirements.txt
+    - pyenv shell 2.6.8; $(pyenv which pip) install -r test-requirements.txt
+    - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.3.1
+    version: 3.3.3
 test:
   override:
     - pip install -r test-requirements.txt

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 from ldclient import LDClient
 
 if __name__ == '__main__':
     apiKey = 'feefifofum'
     client = LDClient(apiKey)
-    print client._apiKey    
+    print(client._apiKey)    

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from past.utils import old_div
 from builtins import object
 import requests
 import json
@@ -211,7 +210,7 @@ def _param_for_user(feature, user):
         idHash += "." + user['secondary']
     hash_key = '%s.%s.%s' % (feature['key'], feature['salt'], idHash)
     hash_val = int(hashlib.sha1(hash_key).hexdigest()[:15], 16)
-    result = old_div(hash_val, __LONG_SCALE__)
+    result = hash_val / __LONG_SCALE__
     return result
 
 
@@ -266,7 +265,7 @@ def _evaluate(feature, user):
 
     total = 0.0
     for variation in feature['variations']:
-        total += old_div(float(variation['weight']), 100.0)
+        total += float(variation['weight']) / 100.0
         if param < total:
             return variation['value']
 

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -209,7 +209,7 @@ def _param_for_user(feature, user):
     if 'secondary' in user:
         idHash += "." + user['secondary']
     hash_key = '%s.%s.%s' % (feature['key'], feature['salt'], idHash)
-    hash_val = int(hashlib.sha1(hash_key).hexdigest()[:15], 16)
+    hash_val = int(hashlib.sha1(hash_key.encode('utf-8')).hexdigest()[:15], 16)
     result = hash_val / __LONG_SCALE__
     return result
 

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -20,6 +20,13 @@ __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
 __BUILTINS__ = ["key", "ip", "country", "email", "firstName", "lastName", "avatar", "name", "anonymous"]
 
+try:
+  unicode
+except NameError:
+  __BASE_TYPES__ = (str, float, int, bool)
+else:
+  __BASE_TYPES__ = (str, float, int, bool, unicode)
+
 class Config(object):
 
     def __init__(self, base_uri, connect_timeout = 2, read_timeout = 10):
@@ -222,7 +229,7 @@ def _match_target(target, user):
         if attr not in user['custom']:
             return False
         u_value = user['custom'][attr]
-        if isinstance(u_value, (str, float, int, bool)):
+        if isinstance(u_value, __BASE_TYPES__):
             return u_value in target['values']
         elif isinstance(u_value, (list, tuple)):
             return len(set(u_value).intersection(target['values'])) > 0

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from past.utils import old_div
+from builtins import object
 import requests
 import json
 import hashlib
@@ -200,8 +203,8 @@ def _param_for_user(feature, user):
     if 'secondary' in user:
         idHash += "." + user['secondary']
     hash_key = '%s.%s.%s' % (feature['key'], feature['salt'], idHash)
-    hash_val = long(hashlib.sha1(hash_key).hexdigest()[:15], 16)
-    result = hash_val / __LONG_SCALE__
+    hash_val = int(hashlib.sha1(hash_key).hexdigest()[:15], 16)
+    result = old_div(hash_val, __LONG_SCALE__)
     return result
 
 
@@ -219,7 +222,7 @@ def _match_target(target, user):
         if attr not in user['custom']:
             return False
         u_value = user['custom'][attr]
-        if isinstance(u_value, (str, unicode, float, int, long, bool)):
+        if isinstance(u_value, (str, float, int, bool)):
             return u_value in target['values']
         elif isinstance(u_value, (list, tuple)):
             return len(set(u_value).intersection(target['values'])) > 0
@@ -256,7 +259,7 @@ def _evaluate(feature, user):
 
     total = 0.0
     for variation in feature['variations']:
-        total += float(variation['weight']) / 100.0
+        total += old_div(float(variation['weight']), 100.0)
         if param < total:
             return variation['value']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 CacheControl==0.10.2
 requests==2.4.0
 future==0.14.3
+past==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 CacheControl==0.10.2
 requests==2.4.0
+future==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 CacheControl==0.10.2
 requests==2.4.0
 future==0.14.3
-past==0.11.1

--- a/testing/test_helper_functions.py
+++ b/testing/test_helper_functions.py
@@ -34,7 +34,7 @@ def test_param_for_user_with_no_key():
 
 
 def test_param_for_user_with_no_secondary():
-    expected = int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+    expected = int(hashlib.sha1('feature.key.abc.xyz'.encode('utf-8')).hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
     assert ldclient._param_for_user(minimal_feature, {u'key': u'xyz'}) == expected
 
 def test_match_target_key_mismatch():
@@ -335,7 +335,7 @@ def test_evaluate_second_variation_target_match():
 
 def test_evaluate_first_variation_no_target_match():
   feature = copy(minimal_feature)
-  hash_value = 100 * int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+  hash_value = 100 * int(hashlib.sha1('feature.key.abc.xyz'.encode('utf-8')).hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
   feature['variations'] = [
     {
       u'value': True,
@@ -369,7 +369,7 @@ def test_evaluate_first_variation_no_target_match():
 
 def test_evaluate_second_variation_no_target_match():
   feature = copy(minimal_feature)
-  hash_value = int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+  hash_value = int(hashlib.sha1('feature.key.abc.xyz'.encode('utf-8')).hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
   feature['variations'] = [
     {
       u'value': True,

--- a/testing/test_helper_functions.py
+++ b/testing/test_helper_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import ldclient
 import hashlib
 from copy import copy
@@ -33,7 +35,7 @@ def test_param_for_user_with_no_key():
 
 
 def test_param_for_user_with_no_secondary():
-    expected = long(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+    expected = old_div(int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16), float(0xFFFFFFFFFFFFFFF))
     assert ldclient._param_for_user(minimal_feature, {u'key': u'xyz'}) == expected
 
 def test_match_target_key_mismatch():
@@ -334,7 +336,7 @@ def test_evaluate_second_variation_target_match():
 
 def test_evaluate_first_variation_no_target_match():
   feature = copy(minimal_feature)
-  hash_value = 100 * long(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+  hash_value = 100 * int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
   feature['variations'] = [
     {
       u'value': True,
@@ -368,7 +370,7 @@ def test_evaluate_first_variation_no_target_match():
 
 def test_evaluate_second_variation_no_target_match():
   feature = copy(minimal_feature)
-  hash_value = long(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
+  hash_value = old_div(int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16), float(0xFFFFFFFFFFFFFFF))
   feature['variations'] = [
     {
       u'value': True,

--- a/testing/test_helper_functions.py
+++ b/testing/test_helper_functions.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from past.utils import old_div
 import ldclient
 import hashlib
 from copy import copy
@@ -35,7 +34,7 @@ def test_param_for_user_with_no_key():
 
 
 def test_param_for_user_with_no_secondary():
-    expected = old_div(int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16), float(0xFFFFFFFFFFFFFFF))
+    expected = int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
     assert ldclient._param_for_user(minimal_feature, {u'key': u'xyz'}) == expected
 
 def test_match_target_key_mismatch():
@@ -370,7 +369,7 @@ def test_evaluate_first_variation_no_target_match():
 
 def test_evaluate_second_variation_no_target_match():
   feature = copy(minimal_feature)
-  hash_value = old_div(int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16), float(0xFFFFFFFFFFFFFFF))
+  hash_value = int(hashlib.sha1('feature.key.abc.xyz').hexdigest()[:15], 16) / float(0xFFFFFFFFFFFFFFF)
   feature['variations'] = [
     {
       u'value': True,

--- a/testing/test_ldclient.py
+++ b/testing/test_ldclient.py
@@ -1,5 +1,8 @@
+from builtins import next
+from builtins import filter
+from builtins import object
 import ldclient
-from itertools import ifilter
+
 
 class MockConsumer(object):
     def __init__(self):
@@ -78,7 +81,7 @@ def test_toggle_event():
   client.toggle('xyz', user, default=None)
   def expected_event(e):
     return e['kind'] == 'feature' and e['key']  == 'xyz' and e['user'] == user and e['value'] == True
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is not None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is not None
 
 
 def test_toggle_offline():
@@ -90,33 +93,33 @@ def test_toggle_event_offline():
   client.toggle('xyz', user, default=None)
   def expected_event(e):
     return e['kind'] == 'feature' and e['key']  == 'xyz' and e['user'] == user and e['value'] == True
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is None
 
 def test_identify():
   client.identify(user)
   def expected_event(e):
     return e['kind'] == 'identify' and e['key']  == u'xyz' and e['user'] == user
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is not None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is not None
 
 def test_identify_offline():
   client.set_offline()
   client.identify(user)
   def expected_event(e):
     return e['kind'] == 'identify' and e['key']  == u'xyz' and e['user'] == user
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is None
 
 def test_track():
   client.track('my_event', user, 42)
   def expected_event(e):
     return e['kind'] == 'custom' and e['key']  == 'my_event' and e['user'] == user and e['data'] == 42
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is not None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is not None
 
 def test_track_offline():
   client.set_offline()
   client.track('my_event', user, 42)
   def expected_event(e):
     return e['kind'] == 'custom' and e['key']  == 'my_event' and e['user'] == user and e['data'] == 42
-  assert next(ifilter(expected_event, mock_buffered_consumer.queue), None) is None
+  assert next(filter(expected_event, mock_buffered_consumer.queue), None) is None
 
 def test_flush_empties_queue():
   client.track('my_event', user, 42)
@@ -135,8 +138,8 @@ def test_flush_sends_events():
     return e['kind'] == 'custom' and e['key']  == 'my_event' and e['user'] == user and e['data'] == 33
 
   assert (
-    next(ifilter(expected_event1, mock_consumer.sent), None) is not None and 
-    next(ifilter(expected_event2, mock_consumer.sent), None) is not None
+    next(filter(expected_event1, mock_consumer.sent), None) is not None and 
+    next(filter(expected_event2, mock_consumer.sent), None) is not None
     )
 
 def test_flush_offline():
@@ -151,6 +154,6 @@ def test_flush_offline():
     return e['kind'] == 'custom' and e['key']  == 'my_event' and e['user'] == user and e['data'] == 33
 
   assert (
-    next(ifilter(expected_event1, mock_consumer.sent), None) is None and 
-    next(ifilter(expected_event2, mock_consumer.sent), None) is None
+    next(filter(expected_event1, mock_consumer.sent), None) is None and 
+    next(filter(expected_event2, mock_consumer.sent), None) is None
     )


### PR DESCRIPTION
This should make our Python SDK compatible with Python 2 and 3. It's currently tested against python 2.6.8 and 3.3.3 (chosen arbitrarily).