### PR TITLE
Add settings to also test python 3.4.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,14 +2,19 @@ dependencies:
   pre:
     - pyenv shell 2.7.10; $(pyenv which pip) install --upgrade pip
     - pyenv shell 3.3.3; $(pyenv which pip) install --upgrade pip
+    - pyenv shell 3.4.2; $(pyenv which pip) install --upgrade pip
     - pyenv shell 2.7.10; $(pyenv which pip) install -r test-requirements.txt
     - pyenv shell 3.3.3; $(pyenv which pip) install -r test-requirements.txt
+    - pyenv shell 3.4.2; $(pyenv which pip) install -r test-requirements.txt
     - pyenv shell 2.7.10; $(pyenv which pip) install -r twisted-requirements.txt
     - pyenv shell 3.3.3; $(pyenv which pip) install -r twisted-requirements.txt
+    - pyenv shell 3.4.2; $(pyenv which pip) install -r twisted-requirements.txt
     - pyenv shell 2.7.10; $(pyenv which python) setup.py install
     - pyenv shell 3.3.3; $(pyenv which python) setup.py install
+    - pyenv shell 3.4.2; $(pyenv which python) setup.py install 
 
 test:
   override:
     - pyenv shell 2.7.10; $(pyenv which py.test) testing
     - pyenv shell 3.3.3; $(pyenv which py.test) --ignore=testing/test_sse_twisted.py -s testing
+    - pyenv shell 3.4.2; $(pyenv which py.test) --ignore=testing/test_sse_twisted.py -s testing


### PR DESCRIPTION
Include python 3.4.2 in the test matrix. 