### PR TITLE
4.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ LaunchDarkly SDK for Python
 [![Circle CI](https://img.shields.io/circleci/project/launchdarkly/python-client.png)](https://circleci.com/gh/launchdarkly/python-client)
 [![Code Climate](https://codeclimate.com/github/launchdarkly/python-client/badges/gpa.svg)](https://codeclimate.com/github/launchdarkly/python-client)
 
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Flaunchdarkly%2Fpython-client.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Flaunchdarkly%2Fpython-client?ref=badge_shield)
+
 [![PyPI](https://img.shields.io/pypi/v/ldclient-py.svg?maxAge=2592000)](https://pypi.python.org/pypi/ldclient-py)
 [![PyPI](https://img.shields.io/pypi/pyversions/ldclient-py.svg)](https://pypi.python.org/pypi/ldclient-py)
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,12 @@ dependencies:
     - pyenv shell 2.7.10; $(pyenv which python) setup.py install
     - pyenv shell 3.3.3; $(pyenv which python) setup.py install
     - pyenv shell 3.4.2; $(pyenv which python) setup.py install 
+    
+    - pyenv shell 2.6.6; $(pyenv which pip) freeze
+    - pyenv shell 2.6.6; $(pyenv which pip) freeze
+    - pyenv shell 2.7.10; $(pyenv which pip) freeze
+    - pyenv shell 3.3.3; $(pyenv which pip) freeze
+    - pyenv shell 3.4.2; $(pyenv which pip) freeze
 
 test:
   override:

--- a/ldclient/event_consumer.py
+++ b/ldclient/event_consumer.py
@@ -28,7 +28,7 @@ class EventConsumerImpl(Thread, EventConsumer):
             try:
                 self.send()
             except Exception:
-                log.exception(
+                log.warning(
                     'Unhandled exception in event consumer')
 
     def stop(self):
@@ -63,11 +63,13 @@ class EventConsumerImpl(Thread, EventConsumer):
                             'ProtocolError exception caught while sending events. Retrying.')
                         do_send(False)
                 else:
-                    log.exception(
-                        'Unhandled exception in event consumer. Analytics events were not processed.')
+                    log.warning(
+                        'Unhandled exception in event consumer. Analytics events were not processed.',
+                        exc_info=True)
             except:
-                log.exception(
-                    'Unhandled exception in event consumer. Analytics events were not processed.')
+                log.warning(
+                    'Unhandled exception in event consumer. Analytics events were not processed.',
+                    exc_info=True)
 
         try:
             do_send(True)

--- a/ldclient/feature_requester.py
+++ b/ldclient/feature_requester.py
@@ -10,28 +10,36 @@ from ldclient.util import log
 
 class FeatureRequesterImpl(FeatureRequester):
     def __init__(self, config):
-        self._session = CacheControl(requests.Session())
+        self._session_cache = CacheControl(requests.Session())
+        self._session_no_cache = requests.Session()
         self._config = config
 
     def get_all(self):
         hdrs = _headers(self._config.sdk_key)
         uri = self._config.get_latest_flags_uri
-        r = self._session.get(uri, headers=hdrs, timeout=(
-            self._config.connect_timeout, self._config.read_timeout))
-        log.debug("All flags response status: " + str(r.status_code) + ". From cache? " + str(r.from_cache) +
-                  ". ETag: " + str(r.headers.get('ETag')))
+        r = self._session_cache.get(uri,
+                                    headers=hdrs,
+                                    timeout=(
+                                        self._config.connect_timeout,
+                                        self._config.read_timeout))
         r.raise_for_status()
-        features = r.json()
-        return features
+        flags = r.json()
+        versions_summary = list(map(lambda f: "{0}:{1}".format(f.get("key"), f.get("version")), flags.values()))
+        log.debug("Get All flags response status:[{0}] From cache?[{1}] ETag:[{2}] flag versions: {3}"
+                  .format(r.status_code, r.from_cache, r.headers.get('ETag'), versions_summary))
+        return flags
 
     def get_one(self, key):
         hdrs = _headers(self._config.sdk_key)
         uri = self._config.get_latest_flags_uri + '/' + key
         log.debug("Getting one feature flag using uri: " + uri)
-        r = self._session.get(uri,
-                              headers=hdrs,
-                              timeout=(self._config.connect_timeout,
-                                       self._config.read_timeout))
+        r = self._session_no_cache.get(uri,
+                                       headers=hdrs,
+                                       timeout=(
+                                           self._config.connect_timeout,
+                                           self._config.read_timeout))
         r.raise_for_status()
-        feature = r.json()
-        return feature
+        flag = r.json()
+        log.debug("Get one flag response status:[{0}] Flag key:[{1}] version:[{2}]"
+                  .format(r.status_code, key, flag.get("version")))
+        return flag

--- a/ldclient/operators.py
+++ b/ldclient/operators.py
@@ -50,7 +50,7 @@ def _parse_time(input):
             timestamp = (parsed_time - epoch).total_seconds()
             return timestamp * 1000.0
         except Exception as e:
-            log.warn("Couldn't parse timestamp:" + str(input) + " with error: " + str(e))
+            log.warn("Couldn't parse timestamp:" + str(input) + " with message: " + str(e))
             return None
 
     log.warn("Got unexpected type: " + type(input) + " with value: " + str(input) + " when attempting to parse time")

--- a/ldclient/streaming.py
+++ b/ldclient/streaming.py
@@ -4,6 +4,7 @@ import json
 from threading import Thread
 
 import backoff
+import time
 
 from ldclient.interfaces import UpdateProcessor
 from ldclient.sse_client import SSEClient
@@ -25,29 +26,38 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
         self._running = False
         self._ready = ready
 
+    # Retry/backoff logic:
+    # Upon any error establishing the stream connection we retry with backoff + jitter.
+    # Upon any error processing the results of the stream we reconnect after one second.
     def run(self):
         log.info("Starting StreamingUpdateProcessor connecting to uri: " + self._uri)
         self._running = True
         while self._running:
-            self._connect()
+            try:
+                messages = self._connect()
+                for msg in messages:
+                    if not self._running:
+                        break
+                    message_ok = self.process_message(self._store, self._requester, msg)
+                    if message_ok is True and self._ready.is_set() is False:
+                        log.info("StreamingUpdateProcessor initialized ok.")
+                        self._ready.set()
+            except Exception:
+                log.warning("Caught exception. Restarting stream connection after one second.",
+                            exc_info=True)
+                time.sleep(1)
 
     def _backoff_expo():
         return backoff.expo(max_value=30)
 
     @backoff.on_exception(_backoff_expo, BaseException, max_tries=None, jitter=backoff.full_jitter)
     def _connect(self):
-        messages = SSEClient(
+        return SSEClient(
             self._uri,
             verify=self._config.verify_ssl,
             headers=_stream_headers(self._config.sdk_key),
             connect_timeout=self._config.connect_timeout,
             read_timeout=stream_read_timeout)
-        for msg in messages:
-            if not self._running:
-                break
-            message_ok = self.process_message(self._store, self._requester, msg, self._ready)
-            if message_ok is True and self._ready.is_set() is False:
-                self._ready.set()
 
     def stop(self):
         log.info("Stopping StreamingUpdateProcessor")
@@ -56,33 +66,37 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
     def initialized(self):
         return self._running and self._ready.is_set() is True and self._store.initialized is True
 
+    # Returns True if we initialized the feature store
     @staticmethod
-    def process_message(store, requester, msg, ready):
-        log.debug("Received stream event {0} with data: {1}".format(msg.event, msg.data))
+    def process_message(store, requester, msg):
         if msg.event == 'put':
-            payload = json.loads(msg.data)
-            store.init(payload)
-            if not ready.is_set() is True and store.initialized is True:
-                log.info("StreamingUpdateProcessor initialized ok")
-                return True
+            flags = json.loads(msg.data)
+            versions_summary = list(map(lambda f: "{0}:{1}".format(f.get("key"), f.get("version")), flags.values()))
+            log.debug("Received put event with {0} flags and versions: {1}".format(len(flags), versions_summary))
+            store.init(flags)
+            return True
         elif msg.event == 'patch':
             payload = json.loads(msg.data)
             key = payload['path'][1:]
-            feature = payload['data']
-            store.upsert(key, feature)
+            flag = payload['data']
+            log.debug("Received patch event for flag key: [{0}] New version: [{1}]"
+                      .format(flag.get("key"), str(flag.get("version"))))
+            store.upsert(key, flag)
         elif msg.event == "indirect/patch":
             key = msg.data
+            log.debug("Received indirect/patch event for flag key: " + key)
             store.upsert(key, requester.get_one(key))
         elif msg.event == "indirect/put":
+            log.debug("Received indirect/put event")
             store.init(requester.get_all())
-            if not ready.is_set() is True and store.initialized is True:
-                log.info("StreamingUpdateProcessor initialized ok")
-                return True
+            return True
         elif msg.event == 'delete':
             payload = json.loads(msg.data)
             key = payload['path'][1:]
             # noinspection PyShadowingNames
             version = payload['version']
+            log.debug("Received delete event for flag key: [{0}] New version: [{1}]"
+                      .format(key, version))
             store.delete(key, version)
         else:
             log.warning('Unhandled event in stream processor: ' + msg.event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-backoff>=1.3.1
-CacheControl>=0.11.7
-requests>=2.11.1
-future>=0.15.2
+backoff>=1.4.3
+CacheControl>=0.12.3
+requests>=2.17.3
+future>=0.16.0
 six>=1.10.0
 pyRFC3339>=1.0
 jsonpickle==0.9.3

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# This script updates the version for the ldclient library and releases it to PyPi
+# It will only work if you have the proper credentials set up in ~/.pypirc
+
+# It takes exactly one argument: the new version.
+# It should be run from the root of this git repo like this:
+#   ./scripts/release.sh 4.0.9
+
+# When done you should commit and push the changes made.
+
+set -uxe
+echo "Starting python-client release."
+
+VERSION=$1
+
+#Update version in ldclient/version.py
+echo "VERSION = \"${VERSION}\"" > ldclient/version.py
+
+# Update version in setup.py
+SETUP_PY_TEMP=./setup.py.tmp
+sed "s/ldclient_version=.*/ldclient_version='${VERSION}'/g" setup.py > ${SETUP_PY_TEMP}
+mv ${SETUP_PY_TEMP} setup.py
+
+python setup.py sdist upload
+
+echo "Done with python-client release"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ import uuid
 
 from pip.req import parse_requirements
 
+ldclient_version='4.0.5'
+
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 python26_reqs = parse_requirements('python2.6-requirements.txt', session=uuid.uuid1())
@@ -42,7 +44,7 @@ class PyTest(Command):
 
 setup(
     name='ldclient-py',
-    version='4.0.5',
+    version=ldclient_version,
     author='LaunchDarkly',
     author_email='team@launchdarkly.com',
     packages=['ldclient'],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.8
 pytest-timeout>=1.0
 redis>=2.10.5
-coverage>=4.3.4
+coverage>=4.3.4,<4.4
 pytest-cov>=2.4.0
 codeclimate-test-reporter>=0.2.1

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -6,9 +6,17 @@ def test_date_operator():
     assert operators.ops.get("before")(-100, 0)
     assert operators.ops.get("before")("1970-01-01T00:00:00Z", 1000)
     assert operators.ops.get("before")("1970-01-01T00:00:00.500Z", 1000)
+    # wrong type:
     assert not operators.ops.get("before")(True, 1000)
     assert operators.ops.get("after")("1970-01-01T00:00:02.500Z", 1000)
+    # malformed timestamp:
     assert not operators.ops.get("after")("1970-01-01 00:00:02.500Z", 1000)
+
+    assert operators.ops.get("before")("1970-01-01T00:00:02+01:00", 1000)
+    assert operators.ops.get("before")(-1000, 1000)
+
+    assert operators.ops.get("after")("1970-01-01T00:00:01.001Z", 1000)
+    assert operators.ops.get("after")("1970-01-01T00:00:00-01:00", 1000)
 
 def test_regex_operator():
     assert operators.ops.get("matches")("hello world", "hello.*rld")


### PR DESCRIPTION
## [4.0.6] - 2017-06-09
### Changed
- Improved error handling when processing stream events
- Replaced 3rd party rfc3339 library for license compliance
- No longer caching `get_one()` responses
