### PR TITLE
Fix import of parse_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ except ImportError:
 import sys
 import uuid
 
-from pip.req import parse_requirements
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
 
 ldclient_version='5.0.3'
 


### PR DESCRIPTION
Starting in pip 10.x, parse_requirements was moved to an internal
namespace to help demonstrate the fact that it is not a public API.

As a workaround until a broader decision can be made about how this
should look long term, this change attepts to perform the import using
the pip 10.x path and if it fails, falls back on the older path.

Fixes #80.