### PR TITLE
prepare 6.0.1 release

### DIFF
--- a/ldclient/event_summarizer.py
+++ b/ldclient/event_summarizer.py
@@ -18,7 +18,7 @@ class EventSummarizer(object):
             counter_key = (event['key'], event['variation'], event['version'])
             counter_val = self.counters.get(counter_key)
             if counter_val is None:
-                counter_val = { 'count': 1, 'value': event['value'], 'default': event['default'] }
+                counter_val = { 'count': 1, 'value': event['value'], 'default': event.get('default') }
                 self.counters[counter_key] = counter_val
             else:
                 counter_val['count'] = counter_val['count'] + 1

--- a/ldclient/util.py
+++ b/ldclient/util.py
@@ -48,9 +48,12 @@ def check_uwsgi():
         # noinspection PyPackageRequirements,PyUnresolvedReferences
         import uwsgi
 
-        if not uwsgi.opt.get('enable-threads'):
-            log.error('The LaunchDarkly client requires the enable-threads option be passed to uWSGI. '
-                        'To learn more, see http://docs.launchdarkly.com/v1.0/docs/python-sdk-reference#configuring-uwsgi')
+        if uwsgi.opt.get('enable-threads'):
+            return
+        if uwsgi.opt.get('threads') is not None and int(uwsgi.opt.get('threads')) > 1:
+            return
+        log.error("The LaunchDarkly client requires the 'enable-threads' or 'threads' option be passed to uWSGI. "
+                    'To learn more, see http://docs.launchdarkly.com/v1.0/docs/python-sdk-reference#configuring-uwsgi')
 
 
 class Event(object):


### PR DESCRIPTION
## [6.0.1] - 2018-05-25

### Fixed:
- Fixed a bug that caused an error message to be logged (`KeyError: 'default'`) when evaluating a prerequisite flag (and that also prevented an analytics event from being sent for that flag).
- When running in uWSGI, the client will no longer log an error message if the `enableThreads` option is absent, as long as the `threads` option has been set to a number greater than 1. ([#84](https://github.com/launchdarkly/python-client/issues/84))