### PR TITLE
prepare 6.0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,38 @@ Quick setup
         ldclient.set_sdk_key("your sdk key")
         client = ldclient.get()
 
+
+HTTPS proxy
+------------
+Python's standard HTTP library provides built-in support for the use of a HTTPS proxy. If the HTTPS_PROXY environment variable is present then the SDK will proxy all network requests through the URL provided.
+
+How to set the HTTPS_PROXY environment variable on Mac/Linux systems:
+```
+export HTTPS_PROXY=https://web-proxy.domain.com:8080
+```
+
+
+How to set the HTTPS_PROXY environment variable on Windows systems:
+```
+set HTTPS_PROXY=https://web-proxy.domain.com:8080
+```
+
+Or it can be set from within python:
+```
+os.environ["https_proxy"] = "https://web-proxy.domain.com:8080"
+```
+
+
+If your proxy requires authentication then you can prefix the URN with your login information:
+```
+export HTTPS_PROXY=http://user:pass@web-proxy.domain.com:8080
+```
+or
+```
+set HTTPS_PROXY=http://user:pass@web-proxy.domain.com:8080
+```
+
+
 Your first feature flag
 -----------------------
 

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -24,7 +24,7 @@ class Config(object):
                  update_processor_class=None,
                  poll_interval=30,
                  use_ldd=False,
-                 feature_store=InMemoryFeatureStore(),
+                 feature_store=None,
                  feature_requester_class=None,
                  event_processor_class=None,
                  private_attribute_names=(),

--- a/ldclient/lru_cache.py
+++ b/ldclient/lru_cache.py
@@ -1,0 +1,51 @@
+'''
+A dictionary-based cache that removes the oldest entries when its limit is exceeded.
+Values are only refreshed by writing, not by reading. Not thread-safe.
+'''
+
+from collections import OrderedDict
+
+
+# Backport of Python 3.2 move_to_end method which doesn't exist in 2.7
+class OrderedDictWithReordering(OrderedDict):
+    if not hasattr(OrderedDict, 'move_to_end'):
+        # backport of Python 3.2 logic
+        def move_to_end(self, key, last=True):
+            link_prev, link_next, key = link = self._OrderedDict__map[key]
+            link_prev[1] = link_next
+            link_next[0] = link_prev
+            root = self._OrderedDict__root
+            if last:
+                last = root[0]
+                link[0] = last
+                link[1] = root
+                last[1] = root[0] = link
+            else:
+                first = root[1]
+                link[0] = root
+                link[1] = first
+                root[1] = first[0] = link
+
+
+class SimpleLRUCache(object):
+    def __init__(self, capacity):
+        self.capacity = capacity
+        self.cache = OrderedDictWithReordering()
+
+    def get(self, key):
+        return self.cache.get(key)
+
+    '''
+    Stores a value in the cache, evicting an old entry if necessary. Returns true if
+    the item already existed, or false if it was newly added.
+    '''
+    def put(self, key, value):
+        found = (key in self.cache)
+        if found:
+            self.cache.move_to_end(key)
+        else:
+            if len(self.cache) >= self.capacity:
+                self.cache.popitem(last=False)
+        self.cache[key] = value
+        return found
+

--- a/ldclient/repeating_timer.py
+++ b/ldclient/repeating_timer.py
@@ -1,16 +1,19 @@
 from threading import Event, Thread
 
-class RepeatingTimer(Thread):
+class RepeatingTimer(object):
     def __init__(self, interval, callable):
-        Thread.__init__(self)
-        self.daemon = True
         self._interval = interval
         self._action = callable
         self._stop = Event()
+        self._thread = Thread(target=self._run)
+        self._thread.daemon = True
 
-    def run(self):
-        while not self._stop.wait(self._interval):
-            self._action()
+    def start(self):
+        self._thread.start()
 
     def stop(self):
         self._stop.set()
+
+    def _run(self):
+        while not self._stop.wait(self._interval):
+            self._action()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ six>=1.10.0
 pyRFC3339>=1.0
 jsonpickle==0.9.3
 semver>=2.7.9
-pylru>=1.0.9

--- a/testing/test_lru_cache.py
+++ b/testing/test_lru_cache.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ldclient.lru_cache import SimpleLRUCache
+
+def test_retains_values_up_to_capacity():
+    lru = SimpleLRUCache(3)
+    assert lru.put("a", True) == False
+    assert lru.put("b", True) == False
+    assert lru.put("c", True) == False
+    assert lru.put("a", True) == True
+    assert lru.put("b", True) == True
+    assert lru.put("c", True) == True
+
+def test_discards_oldest_value_on_overflow():
+    lru = SimpleLRUCache(2)
+    assert lru.put("a", True) == False
+    assert lru.put("b", True) == False
+    assert lru.put("c", True) == False
+    assert lru.get("a") is None
+    assert lru.get("b") == True
+    assert lru.get("c") == True
+
+def test_value_becomes_new_on_replace():
+    lru = SimpleLRUCache(2)
+    assert lru.put("a", True) == False
+    assert lru.put("b", True) == False
+    assert lru.put("a", True) == True  # b is now oldest
+    assert lru.put("c", True) == False  # b is discarded as oldest
+    assert lru.get("a") is True
+    assert lru.get("b") is None
+    assert lru.get("c") is True


### PR DESCRIPTION
## [6.0.3] - 2018-05-30

### Removed:
- Removed a dependency on the `pylru` package, because it uses a GPL license.

### Fixed:
- Fixed a bug that, in Python 3.x, could cause a timer thread to keep running after the client has been shut down. This bug also caused the message "TypeError: Event object is not callable" to be logged.
- Fixed the `Config` initializer to create a new instance of `InMemoryFeatureStore` if you omit the `feature_store` argument. Previously, all `Config` instances that were created with default parameters would share the same feature store instance.
- Clarified HTTP proxy setup instructions in the readme.