### PR TITLE
prepare 6.1.0 release

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -4,7 +4,6 @@ import hashlib
 import hmac
 import threading
 
-import requests
 from builtins import object
 
 from ldclient.config import Config as Config
@@ -42,7 +41,6 @@ class LDClient(object):
             self._config = config or Config.default()
         self._config._validate()
 
-        self._session = CacheControl(requests.Session())
         self._event_processor = None
         self._lock = Lock()
 

--- a/ldclient/feature_requester.py
+++ b/ldclient/feature_requester.py
@@ -1,52 +1,61 @@
 from __future__ import absolute_import
 
-import requests
-from cachecontrol import CacheControl
+from collections import namedtuple
+import json
+import urllib3
 
 from ldclient.interfaces import FeatureRequester
+from ldclient.util import UnsuccessfulResponseException
 from ldclient.util import _headers
+from ldclient.util import create_http_pool_manager
 from ldclient.util import log
+from ldclient.util import throw_if_unsuccessful_response
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 
 LATEST_ALL_URI = '/sdk/latest-all'
 
 
+CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
+
+
 class FeatureRequesterImpl(FeatureRequester):
     def __init__(self, config):
-        self._session_cache = CacheControl(requests.Session())
-        self._session_no_cache = requests.Session()
+        self._cache = dict()
+        self._http = create_http_pool_manager(num_pools=1, verify_ssl=config.verify_ssl)
         self._config = config
 
     def get_all_data(self):
-        hdrs = _headers(self._config.sdk_key)
-        uri = self._config.base_uri + LATEST_ALL_URI
-        r = self._session_cache.get(uri,
-                                    headers=hdrs,
-                                    timeout=(
-                                        self._config.connect_timeout,
-                                        self._config.read_timeout))
-        r.raise_for_status()
-        all_data = r.json()
-        log.debug("Get All flags response status:[%d] From cache?[%s] ETag:[%s]",
-                  r.status_code, r.from_cache, r.headers.get('ETag'))
+        all_data = self._do_request(self._config.base_uri + LATEST_ALL_URI, True)
         return {
             FEATURES: all_data['flags'],
             SEGMENTS: all_data['segments']
         }
 
     def get_one(self, kind, key):
+        return self._do_request(kind.request_api_path + '/' + key, False)
+
+    def _do_request(self, uri, allow_cache):
         hdrs = _headers(self._config.sdk_key)
-        path = kind.request_api_path + '/' + key
-        uri = config.base_uri + path
-        log.debug("Getting %s from %s using uri: %s", key, kind['namespace'], uri)
-        r = self._session_no_cache.get(uri,
-                                       headers=hdrs,
-                                       timeout=(
-                                           self._config.connect_timeout,
-                                           self._config.read_timeout))
-        r.raise_for_status()
-        obj = r.json()
-        log.debug("%s response status:[%d] key:[%s] version:[%d]",
-                  path, r.status_code, key, segment.get("version"))
-        return obj
+        if allow_cache:
+            cache_entry = self._cache.get(uri)
+            if cache_entry is not None:
+                hdrs['If-None-Match'] = cache_entry.etag
+        r = self._http.request('GET', uri,
+                               headers=hdrs,
+                               timeout=urllib3.Timeout(connect=self._config.connect_timeout, read=self._config.read_timeout),
+                               retries=1)
+        throw_if_unsuccessful_response(r)
+        if r.status == 304 and cache_entry is not None:
+            data = cache_entry.data
+            etag = cache_entry.etag
+            from_cache = True
+        else:
+            data = json.loads(r.data.decode('UTF-8'))
+            etag = r.getheader('ETag')
+            from_cache = False
+            if allow_cache and etag is not None:
+                self._cache[uri] = CacheEntry(data=data, etag=etag)
+        log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]",
+            uri, r.status, from_cache, etag)
+        return data

--- a/ldclient/polling.py
+++ b/ldclient/polling.py
@@ -32,6 +32,7 @@ class PollingUpdateProcessor(Thread, UpdateProcessor):
                     log.error('Received unexpected status code %d from polling request' % e.response.status_code)
                     if e.response.status_code == 401:
                         log.error('Received 401 error, no further polling requests will be made since SDK key is invalid')
+                        self._ready.set() # if client is initializing, make it stop waiting; has no effect if already inited
                         self.stop()
                     break
                 except Exception:

--- a/ldclient/polling.py
+++ b/ldclient/polling.py
@@ -2,7 +2,7 @@ from threading import Thread
 
 from ldclient.interfaces import UpdateProcessor
 from ldclient.util import log
-from ldclient.util import UnsuccessfulResponseException
+from ldclient.util import UnsuccessfulResponseException, http_error_message, is_http_error_recoverable
 
 import time
 
@@ -30,15 +30,14 @@ class PollingUpdateProcessor(Thread, UpdateProcessor):
                         log.info("PollingUpdateProcessor initialized ok")
                         self._ready.set()
                 except UnsuccessfulResponseException as e:
-                    log.error('Received unexpected status code %d from polling request' % e.status)
-                    if e.status == 401:
-                        log.error('Received 401 error, no further polling requests will be made since SDK key is invalid')
+                    log.error(http_error_message(e.status, "polling request"))
+                    if not is_http_error_recoverable(e.status):
                         self._ready.set() # if client is initializing, make it stop waiting; has no effect if already inited
                         self.stop()
                     break
-                except Exception:
+                except Exception as e:
                     log.exception(
-                        'Error: Exception encountered when updating flags.')
+                        'Error: Exception encountered when updating flags. %s' % e)
 
                 elapsed = time.time() - start_time
                 if elapsed < self._config.poll_interval:

--- a/ldclient/polling.py
+++ b/ldclient/polling.py
@@ -2,7 +2,8 @@ from threading import Thread
 
 from ldclient.interfaces import UpdateProcessor
 from ldclient.util import log
-from requests import HTTPError
+from ldclient.util import UnsuccessfulResponseException
+
 import time
 
 
@@ -28,9 +29,9 @@ class PollingUpdateProcessor(Thread, UpdateProcessor):
                     if not self._ready.is_set() is True and self._store.initialized is True:
                         log.info("PollingUpdateProcessor initialized ok")
                         self._ready.set()
-                except HTTPError as e:
-                    log.error('Received unexpected status code %d from polling request' % e.response.status_code)
-                    if e.response.status_code == 401:
+                except UnsuccessfulResponseException as e:
+                    log.error('Received unexpected status code %d from polling request' % e.status)
+                    if e.status == 401:
                         log.error('Received 401 error, no further polling requests will be made since SDK key is invalid')
                         self._ready.set() # if client is initializing, make it stop waiting; has no effect if already inited
                         self.stop()

--- a/ldclient/sse_client.py
+++ b/ldclient/sse_client.py
@@ -6,7 +6,10 @@ import warnings
 
 import six
 
-import requests
+import urllib3
+
+from ldclient.util import create_http_pool_manager
+from ldclient.util import throw_if_unsuccessful_response
 
 # Inspired by: https://bitbucket.org/btubbs/sseclient/src/a47a380a3d7182a205c0f1d5eb470013ce796b4d/sseclient.py?at=default&fileviewer=file-view-default
 
@@ -16,7 +19,8 @@ end_of_field = re.compile(r'\r\n\r\n|\r\r|\n\n')
 
 
 class SSEClient(object):
-    def __init__(self, url, last_id=None, retry=3000, connect_timeout=10, read_timeout=300, chunk_size=10000, session=None, **kwargs):
+    def __init__(self, url, last_id=None, retry=3000, connect_timeout=10, read_timeout=300, chunk_size=10000,
+                 verify_ssl=False, http=None, **kwargs):
         self.url = url
         self.last_id = last_id
         self.retry = retry
@@ -24,10 +28,10 @@ class SSEClient(object):
         self._read_timeout = read_timeout
         self._chunk_size = chunk_size
 
-        # Optional support for passing in a requests.Session()
-        self.session = session
+        # Optional support for passing in an HTTP client
+        self.http = create_http_pool_manager(num_pools=1, verify_ssl=verify_ssl)
 
-        # Any extra kwargs will be fed into the requests.get call later.
+        # Any extra kwargs will be fed into the request call later.
         self.requests_kwargs = kwargs
 
         # The SSE spec requires making requests with Cache-Control: nocache
@@ -48,21 +52,22 @@ class SSEClient(object):
             self.requests_kwargs['headers']['Last-Event-ID'] = self.last_id
 
         # Use session if set.  Otherwise fall back to requests module.
-        requester = self.session or requests
-        self.resp = requester.get(
+        self.resp = self.http.request(
+            'GET',
             self.url,
-            stream=True,
-            timeout=(self._connect_timeout, self._read_timeout),
+            timeout=urllib3.Timeout(connect=self._connect_timeout, read=self._read_timeout),
+            preload_content=False,
+            retries=0, # caller is responsible for implementing appropriate retry semantics, e.g. backoff
             **self.requests_kwargs)
 
         # Raw readlines doesn't work because we may be missing newline characters until the next chunk
         # For some reason, we also need to specify a chunk size because stream=True doesn't seem to guarantee
         # that we get the newlines in a timeline manner
-        self.resp_file = self.resp.iter_content(chunk_size=self._chunk_size, decode_unicode=True)
+        self.resp_file = self.resp.stream(amt=self._chunk_size)
 
         # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
         # attribute on Events like the Javascript spec requires.
-        self.resp.raise_for_status()
+        throw_if_unsuccessful_response(self.resp)
 
     def _event_complete(self):
         return re.search(end_of_field, self.buf[len(self.buf)-self._chunk_size-10:]) is not None  # Just search the last chunk plus a bit
@@ -77,8 +82,8 @@ class SSEClient(object):
                 # There are some bad cases where we don't always get a line: https://github.com/requests/requests/pull/2431
                 if not nextline:
                     raise EOFError()
-                self.buf += nextline
-            except (StopIteration, requests.RequestException, EOFError) as e:
+                self.buf += nextline.decode("utf-8")
+            except (StopIteration, EOFError) as e:
                 time.sleep(self.retry / 1000.0)
                 self._connect()
 

--- a/ldclient/streaming.py
+++ b/ldclient/streaming.py
@@ -53,6 +53,7 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                 log.error("Received unexpected status code %d for stream connection" % e.response.status_code)
                 if e.response.status_code == 401:
                     log.error("Received 401 error, no further streaming connection will be made since SDK key is invalid")
+                    self._ready.set()  # if client is initializing, make it stop waiting; has no effect if already inited
                     self.stop()
                     break
                 else:

--- a/ldclient/streaming.py
+++ b/ldclient/streaming.py
@@ -5,12 +5,11 @@ import json
 from threading import Thread
 
 import backoff
-from requests import HTTPError
 import time
 
 from ldclient.interfaces import UpdateProcessor
 from ldclient.sse_client import SSEClient
-from ldclient.util import _stream_headers, log
+from ldclient.util import _stream_headers, log, UnsuccessfulResponseException
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 # allows for up to 5 minutes to elapse without any data sent across the stream. The heartbeats sent as comments on the
@@ -49,35 +48,35 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                     if message_ok is True and self._ready.is_set() is False:
                         log.info("StreamingUpdateProcessor initialized ok.")
                         self._ready.set()
-            except HTTPError as e:
-                log.error("Received unexpected status code %d for stream connection" % e.response.status_code)
-                if e.response.status_code == 401:
+            except UnsuccessfulResponseException as e:
+                log.error("Received unexpected status code %d for stream connection" % e.status)
+                if e.status == 401:
                     log.error("Received 401 error, no further streaming connection will be made since SDK key is invalid")
                     self._ready.set()  # if client is initializing, make it stop waiting; has no effect if already inited
                     self.stop()
                     break
                 else:
                     log.warning("Restarting stream connection after one second.")
-            except Exception:
-                log.warning("Caught exception. Restarting stream connection after one second.",
-                            exc_info=True)
+            except Exception as e:
+                log.warning("Caught exception. Restarting stream connection after one second. %s" % e)
+                # no stacktrace here because, for a typical connection error, it'll just be a lengthy tour of urllib3 internals
             time.sleep(1)
 
     def _backoff_expo():
         return backoff.expo(max_value=30)
 
     def should_not_retry(e):
-        return isinstance(e, HTTPError) and (e.response.status_code == 401)
+        return isinstance(e, UnsuccessfulResponseException) and (e.response.status_code == 401)
 
     @backoff.on_exception(_backoff_expo, BaseException, max_tries=None, jitter=backoff.full_jitter,
                           giveup=should_not_retry)
     def _connect(self):
         return SSEClient(
             self._uri,
-            verify=self._config.verify_ssl,
             headers=_stream_headers(self._config.sdk_key),
             connect_timeout=self._config.connect_timeout,
-            read_timeout=stream_read_timeout)
+            read_timeout=stream_read_timeout,
+            verify_ssl=self._config.verify_ssl)
 
     def stop(self):
         log.info("Stopping StreamingUpdateProcessor")

--- a/ldclient/streaming.py
+++ b/ldclient/streaming.py
@@ -9,7 +9,7 @@ import time
 
 from ldclient.interfaces import UpdateProcessor
 from ldclient.sse_client import SSEClient
-from ldclient.util import _stream_headers, log, UnsuccessfulResponseException
+from ldclient.util import _stream_headers, log, UnsuccessfulResponseException, http_error_message, is_http_error_recoverable
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 # allows for up to 5 minutes to elapse without any data sent across the stream. The heartbeats sent as comments on the
@@ -49,14 +49,11 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                         log.info("StreamingUpdateProcessor initialized ok.")
                         self._ready.set()
             except UnsuccessfulResponseException as e:
-                log.error("Received unexpected status code %d for stream connection" % e.status)
-                if e.status == 401:
-                    log.error("Received 401 error, no further streaming connection will be made since SDK key is invalid")
+                log.error(http_error_message(e.status, "stream connection"))
+                if not is_http_error_recoverable(e.status):
                     self._ready.set()  # if client is initializing, make it stop waiting; has no effect if already inited
                     self.stop()
                     break
-                else:
-                    log.warning("Restarting stream connection after one second.")
             except Exception as e:
                 log.warning("Caught exception. Restarting stream connection after one second. %s" % e)
                 # no stacktrace here because, for a typical connection error, it'll just be a lengthy tour of urllib3 internals
@@ -66,7 +63,7 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
         return backoff.expo(max_value=30)
 
     def should_not_retry(e):
-        return isinstance(e, UnsuccessfulResponseException) and (e.response.status_code == 401)
+        return isinstance(e, UnsuccessfulResponseException) and (not is_http_error_recoverable(e.status))
 
     @backoff.on_exception(_backoff_expo, BaseException, max_tries=None, jitter=backoff.full_jitter,
                           giveup=should_not_retry)

--- a/ldclient/util.py
+++ b/ldclient/util.py
@@ -93,3 +93,18 @@ def create_http_pool_manager(num_pools=1, verify_ssl=False):
 def throw_if_unsuccessful_response(resp):
     if resp.status >= 400:
         raise UnsuccessfulResponseException(resp.status)
+
+
+def is_http_error_recoverable(status):
+    if status >= 400 and status < 500:
+        return (status == 400) or (status == 408) or (status == 429)  # all other 4xx besides these are unrecoverable
+    return True  # all other errors are recoverable
+
+
+def http_error_message(status, context, retryable_message = "will retry"):
+    return "Received HTTP error %d%s for %s - %s" % (
+        status,
+        " (invalid SDK key)" if (status == 401 or status == 403) else "",
+        context,
+        retryable_message if is_http_error_recoverable(status) else "giving up permanently"
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 backoff>=1.4.3
 CacheControl>=0.12.3
-requests>=2.17.3
+certifi>=2018.4.16
 future>=0.16.0
 six>=1.10.0
 pyRFC3339>=1.0
 jsonpickle==0.9.3
 semver>=2.7.9
+urllib3>=1.22.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 mock>=2.0.0
 pytest>=2.8
-pytest-timeout>=1.0
 redis>=2.10.5
 coverage>=4.3.4,<4.4
 pytest-cov>=2.4.0

--- a/testing/stub_util.py
+++ b/testing/stub_util.py
@@ -1,0 +1,107 @@
+from email.utils import formatdate
+from requests.structures import CaseInsensitiveDict
+
+from ldclient.interfaces import EventProcessor, FeatureRequester, UpdateProcessor
+
+
+class MockEventProcessor(EventProcessor):
+    def __init__(self, *_):
+        self._running = False
+        self._events = []
+        mock_event_processor = self
+
+    def stop(self):
+        self._running = False
+
+    def start(self):
+        self._running = True
+
+    def is_alive(self):
+        return self._running
+
+    def send_event(self, event):
+        self._events.append(event)
+
+    def flush(self):
+        pass
+
+class MockFeatureRequester(FeatureRequester):
+    def __init__(self):
+        self.all_data = {}
+        self.exception = None
+
+    def get_all_data(self):
+        if self.exception is not None:
+            raise self.exception
+        return self.all_data
+
+    def get_one(self, kind, key):
+        pass
+
+class MockResponse(object):
+    def __init__(self, status, headers):
+        self._status = status
+        self._headers = headers
+
+    @property
+    def status_code(self):
+        return self._status
+
+    @property
+    def headers(self):
+        return self._headers
+
+    def raise_for_status(self):
+        pass
+
+class MockSession(object):
+    def __init__(self):
+        self._request_data = None
+        self._request_headers = None
+        self._response_status = 200
+        self._server_time = None
+
+    def post(self, uri, headers, timeout, data):
+        self._request_headers = headers
+        self._request_data = data
+        resp_hdr = CaseInsensitiveDict()
+        if self._server_time is not None:
+            resp_hdr['Date'] = formatdate(self._server_time / 1000, localtime=False, usegmt=True)
+        return MockResponse(self._response_status, resp_hdr)
+
+    def close(self):
+        pass
+
+    @property
+    def request_data(self):
+        return self._request_data
+
+    @property
+    def request_headers(self):
+        return self._request_headers
+
+    def set_response_status(self, status):
+        self._response_status = status
+    
+    def set_server_time(self, timestamp):
+        self._server_time = timestamp
+
+    def clear(self):
+        self._request_headers = None
+        self._request_data = None
+
+class MockUpdateProcessor(UpdateProcessor):
+    def __init__(self, config, store, ready):
+        ready.set()
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def is_alive(self):
+        return True
+
+    def initialized(self):
+        return True

--- a/testing/stub_util.py
+++ b/testing/stub_util.py
@@ -44,32 +44,28 @@ class MockResponse(object):
         self._headers = headers
 
     @property
-    def status_code(self):
+    def status(self):
         return self._status
 
-    @property
-    def headers(self):
-        return self._headers
+    def getheader(self, name):
+        return self._headers.get(name.lower())
 
-    def raise_for_status(self):
-        pass
-
-class MockSession(object):
+class MockHttp(object):
     def __init__(self):
         self._request_data = None
         self._request_headers = None
         self._response_status = 200
         self._server_time = None
 
-    def post(self, uri, headers, timeout, data):
+    def request(self, method, uri, headers, timeout, body, retries):
         self._request_headers = headers
-        self._request_data = data
-        resp_hdr = CaseInsensitiveDict()
+        self._request_data = body
+        resp_hdr = dict()
         if self._server_time is not None:
-            resp_hdr['Date'] = formatdate(self._server_time / 1000, localtime=False, usegmt=True)
+            resp_hdr['date'] = formatdate(self._server_time / 1000, localtime=False, usegmt=True)
         return MockResponse(self._response_status, resp_hdr)
 
-    def close(self):
+    def clear(self):
         pass
 
     @property
@@ -86,7 +82,7 @@ class MockSession(object):
     def set_server_time(self, timestamp):
         self._server_time = timestamp
 
-    def clear(self):
+    def reset(self):
         self._request_headers = None
         self._request_data = None
 

--- a/testing/test_event_processor.py
+++ b/testing/test_event_processor.py
@@ -1,13 +1,12 @@
-from email.utils import formatdate
 import json
 import pytest
-from requests.structures import CaseInsensitiveDict
 import time
 
 from ldclient.config import Config
 from ldclient.event_processor import DefaultEventProcessor
-
 from ldclient.util import log
+from testing.stub_util import MockResponse, MockSession
+
 
 default_config = Config()
 user = {
@@ -21,59 +20,6 @@ filtered_user = {
 
 ep = None
 mock_session = None
-
-
-class MockResponse(object):
-    def __init__(self, status, headers):
-        self._status = status
-        self._headers = headers
-
-    @property
-    def status_code(self):
-        return self._status
-
-    @property
-    def headers(self):
-        return self._headers
-
-    def raise_for_status(self):
-        pass
-
-class MockSession(object):
-    def __init__(self):
-        self._request_data = None
-        self._request_headers = None
-        self._response_status = 200
-        self._server_time = None
-
-    def post(self, uri, headers, timeout, data):
-        self._request_headers = headers
-        self._request_data = data
-        resp_hdr = CaseInsensitiveDict()
-        if self._server_time is not None:
-            resp_hdr['Date'] = formatdate(self._server_time / 1000, localtime=False, usegmt=True)
-        return MockResponse(self._response_status, resp_hdr)
-
-    def close(self):
-        pass
-
-    @property
-    def request_data(self):
-        return self._request_data
-
-    @property
-    def request_headers(self):
-        return self._request_headers
-
-    def set_response_status(self, status):
-        self._response_status = status
-    
-    def set_server_time(self, timestamp):
-        self._server_time = timestamp
-
-    def clear(self):
-        self._request_headers = None
-        self._request_data = None
 
 
 def setup_function():

--- a/testing/test_ldclient.py
+++ b/testing/test_ldclient.py
@@ -5,51 +5,13 @@ from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.interfaces import FeatureRequester, FeatureStore, UpdateProcessor
 from ldclient.versioned_data_kind import FEATURES
 import pytest
+from testing.stub_util import MockEventProcessor, MockUpdateProcessor
 from testing.sync_util import wait_until
 
 try:
     import queue
 except:
     import Queue as queue
-
-
-class MockEventProcessor(object):
-    def __init__(self, *_):
-        self._running = False
-        self._events = []
-        mock_event_processor = self
-
-    def stop(self):
-        self._running = False
-
-    def start(self):
-        self._running = True
-
-    def is_alive(self):
-        return self._running
-
-    def send_event(self, event):
-        self._events.append(event)
-
-    def flush(self):
-        pass
-
-
-class MockUpdateProcessor(UpdateProcessor):
-    def __init__(self, config, store, ready):
-        ready.set()
-
-    def start(self):
-        pass
-
-    def stop(self):
-        pass
-
-    def is_alive(self):
-        return True
-
-    def initialized(self):
-        return True
 
 
 client = LDClient(config=Config(base_uri="http://localhost:3000",

--- a/testing/test_polling_processor.py
+++ b/testing/test_polling_processor.py
@@ -1,0 +1,73 @@
+import pytest
+from requests import HTTPError
+import threading
+import time
+
+from ldclient.config import Config
+from ldclient.feature_store import InMemoryFeatureStore
+from ldclient.interfaces import FeatureRequester
+from ldclient.polling import PollingUpdateProcessor
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
+from testing.stub_util import MockFeatureRequester, MockResponse
+
+config = Config()
+pp = None
+mock_requester = None
+store = None
+ready = None
+
+
+def setup_function():
+    global mock_requester, store, ready
+    mock_requester = MockFeatureRequester()
+    store = InMemoryFeatureStore()
+    ready = threading.Event()
+
+def teardown_function():
+    if pp is not None:
+        pp.stop()
+
+def setup_processor(config):
+    global pp
+    pp = PollingUpdateProcessor(config, mock_requester, store, ready)
+    pp.start()
+
+def test_successful_request_puts_feature_data_in_store():
+    flag = {
+        "key": "flagkey"
+    }
+    segment = {
+        "key": "segkey"
+    }
+    mock_requester.all_data = {
+        FEATURES: {
+            "flagkey": flag
+        },
+        SEGMENTS: {
+            "segkey": segment
+        }
+    }
+    setup_processor(config)
+    ready.wait()
+    assert store.get(FEATURES, "flagkey", lambda x: x) == flag
+    assert store.get(SEGMENTS, "segkey", lambda x: x) == segment
+    assert store.initialized
+    assert pp.initialized()
+
+def test_general_connection_error_does_not_cause_immediate_failure():
+    mock_requester.exception = Exception("bad")
+    start_time = time.time()
+    setup_processor(config)
+    ready.wait(0.3)
+    elapsed_time = time.time() - start_time
+    assert elapsed_time >= 0.2
+    assert not pp.initialized()
+
+def test_http_401_error_causes_immediate_failure():
+    mock_requester.exception = HTTPError(response=MockResponse(401, {}))
+    start_time = time.time()
+    setup_processor(config)
+    ready.wait(5.0)
+    elapsed_time = time.time() - start_time
+    assert elapsed_time < 5.0
+    assert not pp.initialized()

--- a/testing/test_polling_processor.py
+++ b/testing/test_polling_processor.py
@@ -1,5 +1,4 @@
 import pytest
-from requests import HTTPError
 import threading
 import time
 
@@ -7,6 +6,7 @@ from ldclient.config import Config
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.interfaces import FeatureRequester
 from ldclient.polling import PollingUpdateProcessor
+from ldclient.util import UnsuccessfulResponseException
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 from testing.stub_util import MockFeatureRequester, MockResponse
 
@@ -64,7 +64,7 @@ def test_general_connection_error_does_not_cause_immediate_failure():
     assert not pp.initialized()
 
 def test_http_401_error_causes_immediate_failure():
-    mock_requester.exception = HTTPError(response=MockResponse(401, {}))
+    mock_requester.exception = UnsuccessfulResponseException(401)
     start_time = time.time()
     setup_processor(config)
     ready.wait(5.0)

--- a/testing/test_polling_processor.py
+++ b/testing/test_polling_processor.py
@@ -64,10 +64,30 @@ def test_general_connection_error_does_not_cause_immediate_failure():
     assert not pp.initialized()
 
 def test_http_401_error_causes_immediate_failure():
-    mock_requester.exception = UnsuccessfulResponseException(401)
-    start_time = time.time()
+    verify_unrecoverable_http_error(401)
+
+def test_http_403_error_causes_immediate_failure():
+    verify_unrecoverable_http_error(401)
+
+def test_http_408_error_does_not_cause_immediate_failure():
+    verify_recoverable_http_error(408)
+
+def test_http_429_error_does_not_cause_immediate_failure():
+    verify_recoverable_http_error(429)
+
+def test_http_500_error_does_not_cause_immediate_failure():
+    verify_recoverable_http_error(500)
+
+def verify_unrecoverable_http_error(status):
+    mock_requester.exception = UnsuccessfulResponseException(status)
     setup_processor(config)
-    ready.wait(5.0)
-    elapsed_time = time.time() - start_time
-    assert elapsed_time < 5.0
+    finished = ready.wait(5.0)
+    assert finished
+    assert not pp.initialized()
+
+def verify_recoverable_http_error(status):
+    mock_requester.exception = UnsuccessfulResponseException(status)
+    setup_processor(config)
+    finished = ready.wait(0.2)
+    assert not finished
     assert not pp.initialized()


### PR DESCRIPTION
## [6.1.0] - 2018-06-15

### Changed:
- The client now uses `urllib3` for HTTP requests, rather than the `requests` package. This change was made because `requests` has a dependency on an LGPL-licensed package, and some of our customers cannot use LGPL code. The networking behavior of the client should be unchanged.
- The client now treats most HTTP 4xx errors as unrecoverable: that is, after receiving such an error, it will not make any more HTTP requests for the lifetime of the client instance, in effect taking the client offline. This is because such errors indicate either a configuration problem (invalid SDK key) or a bug in the client, which will not resolve without a restart or an upgrade. This does not apply if the error is 400, 408, 429, or any 5xx error.
- During initialization, if the client receives any of the unrecoverable errors described above, `ldclient.get()` will return immediately; previously it would continue waiting until a timeout. The `is_initialized()` method will return false in this case.