### PR TITLE
prepare 6.1.1 release

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -22,7 +22,6 @@ except:
     # noinspection PyUnresolvedReferences,PyPep8Naming
     import Queue as queue  # Python 3
 
-from cachecontrol import CacheControl
 from threading import Lock
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 backoff>=1.4.3
-CacheControl>=0.12.3
 certifi>=2018.4.16
 future>=0.16.0
 six>=1.10.0


### PR DESCRIPTION
## [6.1.1] - 2018-06-19

### Fixed:
- Removed an unused dependency on the `CacheControl` package.