### PR TITLE
prepare 6.2.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - test-3.4
       - test-3.5
       - test-3.6
+      - test-3.7
 test-template: &test-template
   steps:
     - checkout
@@ -58,4 +59,9 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.6-jessie
+      - image: redis
+  test-3.7:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.7-rc-stretch
       - image: redis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,5 +63,5 @@ jobs:
   test-3.7:
     <<: *test-template
     docker:
-      - image: circleci/python:3.7-rc-stretch
+      - image: circleci/python:3.7-stretch
       - image: redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Python SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [6.2.0] - 2018-08-03
+### Changed:
+- In streaming mode, each connection failure or unsuccessful reconnection attempt logs a message at `ERROR` level. Previously, this message included the amount of time before the next retry; since that interval is different for each attempt, that meant the `ERROR`-level messages were all unique, which could cause problems for monitors. This has been changed so the `ERROR`-level message is always the same, and is followed by an `INFO`-level message about the time delay. (Note that in order to suppress the default message, the LaunchDarkly client modifies the logger used by the `backoff` package; if you are using `backoff` for some other purpose and _do_ want to see the default message, set `logging.getLogger('backoff').propagate` to `True`.) ([#88](https://github.com/launchdarkly/python-client/issues/88))
+
 ## [6.1.1] - 2018-06-19
 
 ### Fixed:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ashanbrown
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LaunchDarkly SDK for Python
 Supported Python versions
 -------------------------
 
-This version of the LaunchDarkly SDK is compatible with Python 2.7, and Python 3.3 through 3.6.
+This version of the LaunchDarkly SDK is compatible with Python 2.7, and Python 3.3 through 3.7.
 
 Quick setup
 -----------

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ LaunchDarkly SDK for Python
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
 
+Supported Python versions
+-------------------------
+
+This version of the LaunchDarkly SDK is compatible with Python 2.7, and Python 3.3 through 3.6.
+
 Quick setup
 -----------
 

--- a/ldclient/version.py
+++ b/ldclient/version.py
@@ -1,1 +1,1 @@
-VERSION = "6.1.1"
+VERSION = "6.2.0"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def parse_requirements(filename):
     return [line for line in lineiter if line and not line.startswith("#")]
 
 
-ldclient_version='6.1.1'
+ldclient_version='6.2.0'
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 install_reqs = parse_requirements('requirements.txt')


### PR DESCRIPTION
## [6.2.0] - 2018-08-03
### Changed:
- In streaming mode, each connection failure or unsuccessful reconnection attempt logs a message at `ERROR` level. Previously, this message included the amount of time before the next retry; since that interval is different for each attempt, that meant the `ERROR`-level messages were all unique, which could cause problems for monitors. This has been changed so the `ERROR`-level message is always the same, and is followed by an `INFO`-level message about the time delay. (Note that in order to suppress the default message, the LaunchDarkly client modifies the logger used by the `backoff` package; if you are using `backoff` for some other purpose and _do_ want to see the default message, set `logging.getLogger('backoff').propagate` to `True`.) ([#88](https://github.com/launchdarkly/python-client/issues/88))