### PR TITLE
Handle None return from feature store .all()

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -321,6 +321,8 @@ class LDClient(object):
         with_reasons = kwargs.get('with_reasons', False)
         try:
             flags_map = self._store.all(FEATURES, lambda x: x)
+            if flags_map is None:
+                raise ValueError("flags_map is None, aborting")
         except Exception as e:
             log.error("Unable to read flags for all_flag_state: %s" % e)
             return FeatureFlagsState(False)

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -322,7 +322,7 @@ class LDClient(object):
         try:
             flags_map = self._store.all(FEATURES, lambda x: x)
             if flags_map is None:
-                raise ValueError("flags_map is None, aborting")
+                raise ValueError("feature store error")
         except Exception as e:
             log.error("Unable to read flags for all_flag_state: %s" % e)
             return FeatureFlagsState(False)


### PR DESCRIPTION
Fixes a bug where `self._store.all()` returns `None` without throwing an Exception. This would go on to immediately fail on line 328 as `None` does not have `.items()`. Instead, this makes us go through the established error handler and bail out with `FeatureFlagsState(False)`

cc @mattbriancon 