### PR TITLE
Error closing client when LaunchDarkly relay proxy in daemon mode

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -157,6 +157,8 @@ class LDClient(object):
             return
         if self._event_processor:
             self._event_processor.stop()
+        if self._config.use_ldd:
+            return
         if self._update_processor and self._update_processor.is_alive():
             self._update_processor.stop()
 


### PR DESCRIPTION
Do not attempt to read the `_update_processor` attribute when closing the `client` if the client is running in `ldd` mode because initialization of the `_update_processor` attribute does not occur if `use_ldd` is set to true in the config.